### PR TITLE
Bugfix: nr_rect correctly sets the rect height when drawing a single rect

### DIFF
--- a/src/nr-draw.c
+++ b/src/nr-draw.c
@@ -543,7 +543,7 @@ SEXP draw_rect_(SEXP nr_, SEXP x_, SEXP y_, SEXP w_, SEXP h_,
   int *hs = dbl_to_int(h_, &freeh);
 
   int w = ws[0] - 1;
-  int h = ws[0] - 1;
+  int h = hs[0] - 1;
 
 
   int colour = colour_to_integer(colour_);


### PR DESCRIPTION
nr_rect used the width as both width and height when the length of the vectors for x, y, h, and w is 1, because of a small typo.